### PR TITLE
Introducing CUSTOM_POST_CMD

### DIFF
--- a/bootchartd.conf
+++ b/bootchartd.conf
@@ -20,6 +20,15 @@ AUTO_RENDER_FORMAT="png"
 # Output directory for auto-generated boot charts
 AUTO_RENDER_DIR="/var/log"
 
+# Optional: full path to a script to run after collecting data and auto-rendering
+# if enabled (else you could render yourself there, or just rename the rendered
+# output after date and time and archive it in a certain directory for
+# later reference). Hint: in the script, you may source /etc/bootchartd.conf for
+# being able to use the variables defined there in a flexible way, check the
+# command-line options of pybootchargui and the bootchartd script itself as a
+# source of inspiration;
+CUSTOM_POST_CMD=""
+
 # The processes we have to wait for
 EXIT_PROC="kdm_greet xterm konsole gnome-terminal metacity mutter compiz ldm icewm-session enlightenment"
 

--- a/bootchartd.in
+++ b/bootchartd.in
@@ -132,6 +132,11 @@ stop()
 		cd $AUTO_RENDER_DIR
 		/usr/bin/pybootchartgui -o "$AUTO_RENDER_DIR"/bootchart.$AUTO_RENDER_FORMAT -f $AUTO_RENDER_FORMAT "$BOOTLOG_DEST"
 	fi
+
+	# execute custom post-collect (and possibly post-render) command (which could get params from the conf file by itself if needed)
+	if [ -x "$CUSTOM_POST_CMD" ]; then
+		"$CUSTOM_POST_CMD"
+	fi
 }
 
 if [ $$ -eq 1 ]; then


### PR DESCRIPTION
This as the comment in bootchart.conf says introduces a possibility to run a command after the bootchart.tgz is generated. Could be used for all kinds of fun (like collecting, marking and archiving the traces).
