### PR TITLE
ZeroDivisionError workaround

### DIFF
--- a/pybootchartgui/parsing.py
+++ b/pybootchartgui/parsing.py
@@ -429,6 +429,9 @@ def _parse_proc_disk_stat_log(file, numCpu):
     disk_stats = []
     for sample1, sample2 in zip(disk_stat_samples[:-1], disk_stat_samples[1:]):
         interval = sample1.time - sample2.time
+        if (interval == 0 ):
+            interval=1
+
         sums = [ a - b for a, b in zip(sample1.diskdata, sample2.diskdata) ]
         readTput = sums[0] / 2.0 * 100.0 / interval
         writeTput = sums[1] / 2.0 * 100.0 / interval

--- a/pybootchartgui/samples.py
+++ b/pybootchartgui/samples.py
@@ -111,6 +111,8 @@ class Process:
         self.active = (activeCount>2)
 
     def calc_load(self, userCpu, sysCpu, interval):
+        if (interval == 0 ):
+            interval=1
         userCpuLoad = float(userCpu - self.last_user_cpu_time) / interval
         sysCpuLoad = float(sysCpu - self.last_sys_cpu_time) / interval
         cpuLoad = userCpuLoad + sysCpuLoad


### PR DESCRIPTION
Sometimes the log files may contain two samples timed with at same number. Running the script would fail because of interval division in parsing.py and samples.py. I've added ZeroDivisionError workaround by setting interval=1 if interval=0.

Also seen on http://code.google.com/p/pybootchartgui/issues/detail?id=13
