### PR TITLE
Tweak for command line default path(s).

### DIFF
--- a/pybootchartgui/main.py.in
+++ b/pybootchartgui/main.py.in
@@ -118,8 +118,8 @@ def main(argv=None):
 		writer = _mk_writer(options)
 
 		if len(args) == 0:
-			print("No path given, trying /var/log/bootchart.tgz")
-			args = [ "/var/log/bootchart.tgz" ]
+			print("No path given, trying /var/log/bootchart.tgz and /var/log/bootchart/")
+			args = [ "/var/log/bootchart.tgz", "/var/log/bootchart/" ]
 
 		res = parsing.Trace(writer, args, options)
 


### PR DESCRIPTION
Add /var/log/bootchart/ to the defaults, when no path given at command line.

At least one distribution decided to move things into /var/log/bootchart/\* and forgot to test the command line afterwards!  For those distributions, this code change should allow them to work properly.  Hopefully, no one else could be negatively impacted by the change.
