### PR TITLE
This commit adds gnome-shell to the EXIT_PROC variable

### DIFF
--- a/bootchartd.conf
+++ b/bootchartd.conf
@@ -30,5 +30,5 @@ AUTO_RENDER_DIR="/var/log"
 CUSTOM_POST_CMD=""
 
 # The processes we have to wait for
-EXIT_PROC="kdm_greet xterm konsole gnome-terminal metacity mutter compiz ldm icewm-session enlightenment"
+EXIT_PROC="kdm_greet xterm konsole gnome-terminal metacity mutter gnome-shell compiz ldm icewm-session enlightenment"
 

--- a/bootchartd.in
+++ b/bootchartd.in
@@ -40,7 +40,7 @@ AUTO_RENDER_DIR="/var/log"
 AUTO_RENDER_FORMAT="png"
 
 # The processes we have to wait for
-EXIT_PROC="kdm_greet xterm konsole gnome-terminal metacity mutter compiz ldm icewm-session enlightenment"
+EXIT_PROC="kdm_greet xterm konsole gnome-terminal metacity mutter gnome-shell compiz ldm icewm-session enlightenment"
 
 # Read configuration.
 CONF="/etc/bootchartd.conf"


### PR DESCRIPTION
On my gnome 3 system the actual WM is gnome-shell, so we need to check for
this one. This is most likely the case on all statndard gnome3 systems.
