### PR TITLE
Make component naming and paths more flexible

### DIFF
--- a/bootchart-done.service.in
+++ b/bootchart-done.service.in
@@ -6,15 +6,16 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=Stop Bootchart after Completed Startup
+Description=Stop Read-Ahead Data Collection
 DefaultDependencies=no
 Conflicts=shutdown.target
 After=default.target
 Before=shutdown.target
 
-[Timer]
-OnActiveSec=20s
+[Service]
+Type=oneshot
+ExecStart=@EARLY_PREFIX@/sbin/@PROGRAM_PREFIX@bootchartd@PROGRAM_SUFFIX@ stop
 
 [Install]
-Also=bootchart.service
+Also=@PROGRAM_PREFIX@bootchart@PROGRAM_SUFFIX@.service
 

--- a/bootchart-done.timer.in
+++ b/bootchart-done.timer.in
@@ -6,16 +6,15 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=Collect Bootchart Data
+Description=Stop Bootchart after Completed Startup
 DefaultDependencies=no
-Wants=bootchart-done.timer
 Conflicts=shutdown.target
-Before=basic.target shutdown.target
+After=default.target
+Before=shutdown.target
 
-[Service]
-Type=notify
-ExecStart=/sbin/bootchartd start
-RemainAfterExit=yes
+[Timer]
+OnActiveSec=20s
 
 [Install]
-WantedBy=default.target
+Also=@PROGRAM_PREFIX@bootchart@PROGRAM_SUFFIX@.service
+

--- a/bootchart.service.in
+++ b/bootchart.service.in
@@ -6,16 +6,16 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=Stop Read-Ahead Data Collection
+Description=Collect Bootchart Data
 DefaultDependencies=no
+Wants=@PROGRAM_PREFIX@bootchart@PROGRAM_SUFFIX@-done.timer
 Conflicts=shutdown.target
-After=default.target
-Before=shutdown.target
+Before=basic.target shutdown.target
 
 [Service]
-Type=oneshot
-ExecStart=/sbin/bootchartd stop
+Type=notify
+ExecStart=@EARLY_PREFIX@/sbin/@PROGRAM_PREFIX@bootchartd@PROGRAM_SUFFIX@ start
+RemainAfterExit=yes
 
 [Install]
-Also=bootchart.service
-
+WantedBy=default.target

--- a/bootchartd.in
+++ b/bootchartd.in
@@ -23,8 +23,11 @@
 # our 'proc' without having to touch a (potentially) read-only
 # file-system.
 LIBDIR="@LIBDIR@"
-TMPFS="${LIBDIR}/bootchart/tmpfs"
-COLLECTOR_BIN="${LIBDIR}/bootchart/bootchart-collector"
+PKGLIBDIR="@PKGLIBDIR@"
+PROGRAM_PREFIX="@PROGRAM_PREFIX@"
+PROGRAM_SUFFIX="@PROGRAM_SUFFIX@"
+TMPFS="${PKGLIBDIR}/tmpfs"
+COLLECTOR_BIN="${PKGLIBDIR}/${PROGRAM_PREFIX}bootchart${PROGRAM_SUFFIX}-collector"
 
 # some initrds don't have usleep etc.
 USLEEP="$COLLECTOR_BIN --usleep"
@@ -56,9 +59,10 @@ EXIT_PROC="compiz \
 	xterm"
 
 # Read configuration.
-CONF="/etc/bootchartd.conf"
-if [ -f $PWD/bootchartd.conf ]; then
-	. $PWD/bootchartd.conf
+CONFBASE="${PROGRAM_PREFIX}bootchartd${PROGRAM_SUFFIX}"
+CONF="/etc/${CONFBASE}.conf"
+if [ -f $PWD/${CONFBASE}.conf ]; then
+	. $PWD/${CONFBASE}.conf
 elif [ -f $CONF ]; then
 	. $CONF
 else
@@ -193,10 +197,14 @@ if [ $$ -eq 1 ]; then
 		fi
 		if [ "${i%%=*}" = "init" ]; then
 			_init=${i#*=}
-			if test "$_init" != "/sbin/bootchartd"; then
-				init="$_init"
-				break
-			fi
+			case "$_init" in
+				(*/sbin/*bootchartd*)
+					;;
+				(*)
+					init="$_init"
+					break
+					;;
+			esac
 		fi
 	done
 	export PATH=$OLDPATH

--- a/collector/collector.c
+++ b/collector/collector.c
@@ -657,8 +657,9 @@ enter_environment (int console_debug)
 
 	/* we need our tmpfs to look like this file-system,
 	   so we can chroot into it if necessary */
-	mkdir (TMPFS_PATH "/lib", 0777);
-	mkdir (TMPFS_PATH "/lib/bootchart", 0777);
+	mkdir (TMPFS_PATH EARLY_PREFIX, 0777);
+	mkdir (TMPFS_PATH EARLY_PREFIX LIBDIR, 0777);
+	mkdir (TMPFS_PATH PKGLIBDIR, 0777);
 	if (symlink ("../..", TMPFS_PATH TMPFS_PATH)) {
 		if (errno != EEXIST) {
 			fprintf (stderr, "bootchart-collector failed to create a chroot at "

--- a/collector/common.h
+++ b/collector/common.h
@@ -35,10 +35,10 @@
 #include <pthread.h>
 
 /* Magic path we mount our tmpfs on, inside which we do everything */
-#define TMPFS_PATH "/lib/bootchart/tmpfs"
-#define PROC_PATH  "/lib/bootchart/tmpfs/proc"
+#define TMPFS_PATH PKGLIBDIR "/tmpfs"
+#define PROC_PATH  PKGLIBDIR "/tmpfs/proc"
 /* where we lurk to get move mounted into the live system */
-#define MOVE_DEV_PATH "/dev/.bootchart"
+#define MOVE_DEV_PATH "/dev/." PROGRAM_PREFIX "bootchart" PROGRAM_SUFFIX
 
 /* helpers */
 #undef	MAX

--- a/collector/dump.c
+++ b/collector/dump.c
@@ -265,7 +265,7 @@ bootchart_find_running_pid (Arguments *opt_args)
 			continue;
 		link_target[len] = '\0';
 
-		if (strstr (link_target, "bootchart-collector")) {
+		if (strstr (link_target, PROGRAM_PREFIX "bootchart" PROGRAM_SUFFIX "-collector")) {
 			FILE *argf;
 			int harmless = 0;
 


### PR DESCRIPTION
- support for prefix/suffix so it can coexist with the other projects
  that call themselves bootchart, e.g. by calling itself
  mmeeks-bootchart or bootchart2
- support for distributions with /usr unification (build with EARLY_PREFIX=/usr)
- support for distributions that use lib64 (e.g. Fedora, OpenSUSE) or
  lib/${gnu_tuple} (e.g. Debian, Ubuntu)
