### PR TITLE
Just a minor fix for a problem I encountered while using the tool.

### DIFF
--- a/pybootchartgui/parsing.py
+++ b/pybootchartgui/parsing.py
@@ -394,16 +394,17 @@ def _parse_proc_stat_log(file):
         # CPU times {user, nice, system, idle, io_wait, irq, softirq}
         tokens = lines[0].split()
         times = [ int(token) for token in tokens[1:] ]
-        if ltimes:
-            user = float((times[0] + times[1]) - (ltimes[0] + ltimes[1]))
-            system = float((times[2] + times[5] + times[6]) - (ltimes[2] + ltimes[5] + ltimes[6]))
-            idle = float(times[3] - ltimes[3])
-            iowait = float(times[4] - ltimes[4])
+        if times and len(times) >= 7:
+            if ltimes:
+                user = float((times[0] + times[1]) - (ltimes[0] + ltimes[1]))
+                system = float((times[2] + times[5] + times[6]) - (ltimes[2] + ltimes[5] + ltimes[6]))
+                idle = float(times[3] - ltimes[3])
+                iowait = float(times[4] - ltimes[4])
 
-            aSum = max(user + system + idle + iowait, 1)
-            samples.append( CPUSample(time, user/aSum, system/aSum, iowait/aSum) )
+                aSum = max(user + system + idle + iowait, 1)
+                samples.append( CPUSample(time, user/aSum, system/aSum, iowait/aSum) )
 
-        ltimes = times
+            ltimes = times
         # skip the rest of statistics lines
     return samples
 


### PR DESCRIPTION
This fixes a rare IndexError exception when 'times' is empty due to an
incomplete entry in proc_stat.log.
