### PR TITLE
Enabling the cross compile and  fixing some bugs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ substitute_variables = \
 		-e "s:@PKGLIBDIR@:$(PKGLIBDIR):" \
 		-e "s:@PROGRAM_PREFIX@:$(PROGRAM_PREFIX):" \
 		-e "s:@PROGRAM_SUFFIX@:$(PROGRAM_SUFFIX):" \
+		-e "s:@EARLY_PREFIX@:$(EARLY_PREFIX):" \
 		-e "s:@VER@:$(VER):"
 
 bootchartd: bootchartd.in


### PR DESCRIPTION
Below items are made in these patches. 
- Makefile: Fix @EARLY_PREFIX@ error
- Makefile: Clean systemd unit files
- Add CROSS_COMPILE option

Thank you for accepting in advances.
