### PR TITLE
fix chdir () in buffers_extract_and_dump being disabled for non-debug bu...

### DIFF
--- a/collector/macro.h
+++ b/collector/macro.h
@@ -22,7 +22,7 @@
 #define assert(expr)		assert_debug(expr)
 #else
 #define log(fmt,...)		fprintf(stderr, PREFIX fmt, ##__VA_ARGS__)
-#define assert(expr)		do {} while(0)
+#define assert(expr)		expr
 #endif /* CONFIG_DEBUG */
 
 #endif /* BOOTCHART_MACRO_H */


### PR DESCRIPTION
...ilds

This was caused by an incorrect implementation of a no-op assert macro and
caused "bootchartd stop" to fail under certain circumstances.

This fixes issue #51
