### PR TITLE
Use /bin/sh instead of /bin/bash in bootchartd script

### DIFF
--- a/bootchartd.in
+++ b/bootchartd.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Bootchart logger script
 # Ziga Mahkovec  <ziga.mahkovec@klika.si>


### PR DESCRIPTION
Given that there are no bashisms in this script, there's no reason to require bash instead of sh.
