### PR TITLE
Fix dump buffers on Sparc

### DIFF
--- a/collector/dump.c
+++ b/collector/dump.c
@@ -176,7 +176,8 @@ static void dump_buffers (DumpState *s)
 		Chunk *c = (Chunk *)&buffer;
 		size_t addr = (size_t) s->map.chunks[i];
 
-		pread (s->mem, &buffer, CHUNK_SIZE, addr);
+		lseek (s->mem, addr, SEEK_SET);
+		read (s->mem, &buffer, CHUNK_SIZE);
 		/*      log ("type: '%s' len %d\n",
 			c->dest_stream, (int)c->length); */
 


### PR DESCRIPTION
Fix for Linux Sparc where heap addresses have their MSB set, a case that `pread()` can't handle.

Indeed Linux's `pread()` implementation has a limitation: it treats the offset argument as a _signed_ offset, hence it can't access the top half of the memory space.
And on Sparc, heap addresses have their MSB set, for example:
```
[~]# cat /proc/self/maps | grep 'rw-p'
7fefff28000-7fefff4a000 rw-p 00000000 00:00 0                            [stack]
fffffc0100000000-fffffc0100002000 rw-p 00000000 00:00 0
fffffc0100004000-fffffc0100006000 rw-p 00000000 00:00 0
```
So the problem with bootchart-collector using `pread()` to read from `/dev/{pid}/mem` becomes obvious: the first call to `pread()` successfully reads from the stack, but subsequent calls fail reading from the heap and return `EINVAL`.
The fix is to replace the call to `pread()` by two system calls: `lseek()` which can handle unsigned offsets and then `read()`. There is no real performance degradation and it is portable.