### PR TITLE
Fixed: Missing default value for BOOTLOG_DEST

### DIFF
--- a/bootchartd.in
+++ b/bootchartd.in
@@ -37,7 +37,7 @@ PATH="/sbin:/bin:/usr/sbin:/usr/bin:$PATH"
 
 # Defaults, in case we can't find our configuration
 SAMPLE_HZ=50
-BUILDLOG_DEST=/var/log/bootchart.tgz
+BOOTLOG_DEST=/var/log/bootchart.tgz
 AUTO_RENDER="no"
 AUTO_RENDER_DIR="/var/log"
 AUTO_RENDER_FORMAT="png"


### PR DESCRIPTION
BUILDLOG_DEST seems to be a typo or mix-up which was introduced with 281d1df80884bf2969c509ec60ee8a6593524fe8