### PR TITLE
include sys/sysmacros.h for major/minor/makedev

### DIFF
--- a/collector/collector.c
+++ b/collector/collector.c
@@ -33,6 +33,7 @@
 #include "common.h"
 
 #include <sys/mount.h>
+#include <sys/sysmacros.h>
 #include <linux/fs.h>
 #include <linux/genetlink.h>
 #include <linux/taskstats.h>


### PR DESCRIPTION
These funcs are defined in the sys/sysmacros.h header, not sys/types.h.
Linux C libraries are updating to drop the implicit include, so we need
to include it explicitly.