### PR TITLE
Configuration update for KDE's Plasma 5 (using sddm)

### DIFF
--- a/bootchartd.conf
+++ b/bootchartd.conf
@@ -43,5 +43,6 @@ EXIT_PROC="compiz \
         metacity \
         mutter \
         openbox \
+        sddm-helper \
         xfwm4 \
         xterm"


### PR DESCRIPTION
Added the sddm-helper to the processes we have to wait for. This is needed for KDE's Plasma 5, which uses sddm instead of kdm.

The sddm process always starts the sddm-helper, which in turn can start the sddm-greeter. However, you can configure auto-login for sddm, in which case the sddm-helper will not start the sddm-greeter process. So it seems like sddm-helper is the correct process to wait for. 