### PR TITLE
Ignore SIGHUP when starting as PID 1

### DIFF
--- a/bootchartd.in
+++ b/bootchartd.in
@@ -100,6 +100,8 @@ start()
 # Wait for the boot process to end.
 wait_boot()
 {
+	trap "" SIGHUP
+
 	# Wait for /proc first - without it we have issues
 	while [ ! -e /proc/cmdline ]; do
 		$USLEEP 5000

--- a/collector/collector.c
+++ b/collector/collector.c
@@ -840,6 +840,8 @@ int main (int argc, char *argv[])
 		return 0;
 	}
 
+	signal(SIGHUP, SIG_IGN);
+
 	if (enter_environment (args.console_debug))
 		return 1;
 


### PR DESCRIPTION
On my CentOS 7 box, after systemd pid 1 takes over, it does

  ioctl("/dev/tty", TIOCNOTTY);

which, according to

  http://man7.org/linux/man-pages/man4/tty.4.html

sends SIGHUP to its process group.

bootchart-collector and wait_boot happen to be in this group,
and are thus killed, causing data collection to stop.