### PR TITLE
draw.py: tolerate total_time == 0

### DIFF
--- a/pybootchartgui/draw.py
+++ b/pybootchartgui/draw.py
@@ -645,7 +645,7 @@ def draw_cuml_graph(ctx, proc_tree, chart_bounds, duration, sec_w, stat_type):
 
 	# all the sample times
 	times = sorted(time_hash)
-	if len (times) < 2:
+	if len (times) < 2 or total_time == 0:
 		print("degenerate boot chart")
 		return
 


### PR DESCRIPTION
Sometimes I get all 0s in sample.cpu_sample.sample_value,
and pybootchartgui crashes with division by zero.