### PR TITLE
fix CROSS_COMPILE prefix in CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PKG_NAME=bootchart2
 PKG_TARBALL=$(PKG_NAME)-$(VER).tar.bz2
 
 CROSS_COMPILE ?= $(CONFIG_CROSS_COMPILE:"%"=%)
+CC = $(CROSS_COMPILE)gcc
 
-CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -g -Wall -O0
 CPPFLAGS ?=
 


### PR DESCRIPTION
Hello,

With gnu make (4.1), I wasn't able to override `CC` value with `CROSS_COMPILE`.
To find out what's really going on, I've added this temporary build target to dump variables

```
print-%  : ; @echo $* = $($*)
```
Whenever I pass `CONFIG_CROSS_COMPILE` via environment, it was getting assigned to `CROSS_COMPILE` but `make` was not changing the default value of `CC` due to `?=` operator:

```
$ CONFIG_CROSS_COMPILE=arm-linux-gnueabihf- make print-CROSS_COMPILE print-CC
CROSS_COMPILE = arm-linux-gnueabihf-
CC = cc
```

So I've replaced the `?=` operator with `=`. _(This will prevent `CC=compiler make` definitions from working properly but  that can be resolved by `CC=compiler make -e`, if needed.)_