### PR TITLE
collector: include missing header for makedev

### DIFF
--- a/collector/collector.c
+++ b/collector/collector.c
@@ -39,6 +39,7 @@
 #include <linux/taskstats.h>
 #include <linux/cgroupstats.h>
 #include <signal.h>
+#include <sys/sysmacros.h>
 
 /* pid uniqifying code */
 typedef struct {


### PR DESCRIPTION
I could not compile on Archlinux without this include. Otherwise, I had that error:

> collector.c:(.text.startup+0x18c): undefined reference to `makedev'