### PR TITLE
pybootchartgui: fixup diskstats parsing for recent kernels

### DIFF
--- a/pybootchartgui/parsing.py
+++ b/pybootchartgui/parsing.py
@@ -455,7 +455,7 @@ def _parse_proc_disk_stat_log(file, numCpu):
 
     # this gets called an awful lot.
     def is_relevant_line(linetokens):
-        if len(linetokens) != 14:
+        if len(linetokens) < 14:
             return False
         disk = linetokens[2]
         return disk_regex_re.match(disk)


### PR DESCRIPTION
Newer kernels added new fields to the file, play it safe and reject only
lines with less than 14 tokens.

Reference:
https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats

Thanks Dominic Lemire for reporting.

Fixes #87