### PR TITLE
Do not include linux/fs.h

### DIFF
--- a/collector/collector.c
+++ b/collector/collector.c
@@ -34,7 +34,6 @@
 
 #include <sys/mount.h>
 #include <sys/sysmacros.h>
-#include <linux/fs.h>
 #include <linux/genetlink.h>
 #include <linux/taskstats.h>
 #include <linux/cgroupstats.h>


### PR DESCRIPTION
This header is not needed to be included anymore, moreover it conflicts
with sys/mount.h from glibc 2.36+ see [1]

[1] https://sourceware.org/glibc/wiki/Release/2.36

Signed-off-by: Khem Raj <raj.khem@gmail.com>